### PR TITLE
[Emergency] bukkit PluginMessageReceiver add null-check/delay 20Ticks

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
@@ -1,5 +1,7 @@
 package com.sekwah.advancedportals.bukkit;
 
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
 import com.sekwah.advancedportals.bukkit.api.events.WarpEvent;
 import com.sekwah.advancedportals.bukkit.api.portaldata.PortalArg;
 import com.sekwah.advancedportals.bukkit.listeners.Listeners;

--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
@@ -1,7 +1,5 @@
 package com.sekwah.advancedportals.bukkit;
 
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import com.sekwah.advancedportals.bukkit.api.events.WarpEvent;
 import com.sekwah.advancedportals.bukkit.api.portaldata.PortalArg;
 import com.sekwah.advancedportals.bukkit.listeners.Listeners;

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
@@ -20,7 +20,6 @@ public class PluginMessageReceiver implements PluginMessageListener {
 
     @Override
     public void onPluginMessageReceived(String channel, Player player, byte[] message) {
-        // plugin.getLogger().info(""+channel.equals(plugin.channelName));
 
         if (!channel.equals(plugin.channelName)) {
             return;
@@ -29,22 +28,18 @@ public class PluginMessageReceiver implements PluginMessageListener {
         ByteArrayDataInput in = ByteStreams.newDataInput(message);
         String subchannel = in.readUTF();
 
-        // plugin.getLogger().info("bukkit plugin received: " + subchannel);
-
         if (subchannel.equals("BungeePortal")) {
             String targetPlayerUUID = in.readUTF();
             String targetDestination = in.readUTF();
 
-            OfflinePlayer msgPlayer = plugin.getServer().getOfflinePlayer(UUID.fromString(targetPlayerUUID));
+            Player msgPlayer = plugin.getServer().getPlayer(UUID.fromString(targetPlayerUUID));
 
-            Destination.warp(msgPlayer.getPlayer(), targetDestination);
-
-            /* plugin.PlayerDestiMap.put(msgPlayer, targetDestination);
-
-            plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () ->
-                plugin.PlayerDestiMap.remove(msgPlayer),
-                20L*10
-            ); */
+            if (msgPlayer != null) {
+                plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin,
+                        () -> Destination.warp(msgPlayer, targetDestination),
+                        20L
+                );
+            }
         }
     }
 

--- a/src/main/java/com/sekwah/advancedportals/bungee/listener/PluginMessageReceiver.java
+++ b/src/main/java/com/sekwah/advancedportals/bungee/listener/PluginMessageReceiver.java
@@ -20,14 +20,10 @@ public class PluginMessageReceiver implements Listener {
         ByteArrayDataInput in = ByteStreams.newDataInput(event.getData());
         String subChannel = in.readUTF();
 
-        plugin.getProxy().getLogger().info("bungee plugin received: " + subChannel);
-
         if (subChannel.equalsIgnoreCase("PortalEnter")) {
             String targetServer = in.readUTF();
             String targetPlayerUUID = in.readUTF();
             String targetDestination = in.readUTF();
-
-           //  plugin.getProxy().getLogger().info(targetServer + " " + targetPlayerUUID + " " + targetDestination);
 
             plugin.PlayerDestiMap.put(targetPlayerUUID, new String[]{targetServer, targetDestination});
 


### PR DESCRIPTION
When using this plugin, there was an issue where the first connected user did not warp to the desired location. So I thought of a delay for 20 ticks, which actually worked. This seems to be an issue because first-time users go through more steps than previously connected users.

And I added logic to check if the user information coming into the PluginMessageChannel is actually the user connected to the server. When I tried to connect to the server and tweaked it, I checked that an error occurred because the null check did not work properly.