### PR TITLE
Fixed issue where help menu appears on successful warp

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
@@ -77,9 +77,10 @@ public class AdvancedPortalsCommand implements CommandExecutor, TabCompleter {
                                     break;
                                 }
                             }
+                        } else if (args.length == 1 && player.hasPermission("advancedportals.portal.warp") {
+                            sendMenu(player, "Help Menu: Warp",
+                                    "\u00A76/" + command + " warp <name> \u00A7a- teleport to warp name");
                         }
-                        sendMenu(player, "Help Menu: Warp",
-                                "\u00A76/" + command + " warp <name> \u00A7a- teleport to warp name");
                         break;
                     case "wand":
                     case "selector":


### PR DESCRIPTION
Added else if statement at line 80 checking for single arg instead of 2. This should now only appear if a player both has permission and has not specified a portal to warp to.