### PR TITLE
Fix timing issues with bungeecord destination warps

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
@@ -12,6 +12,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.HashMap;
+
 public class AdvancedPortalsPlugin extends JavaPlugin {
 
     //public CraftBukkit compat = null;

--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
@@ -21,7 +21,7 @@ public class AdvancedPortalsPlugin extends JavaPlugin {
 
     public boolean registeredBungeeChannels = false;
 
-    // public HashMap<OfflinePlayer, String> PlayerDestiMap = new HashMap<>();
+    public HashMap<String, String> PlayerDestiMap = new HashMap<>();
 
     public void onEnable() {
 

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
@@ -89,7 +89,20 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void onJoinEvent(PlayerJoinEvent event) {
-        Portal.joinCooldown.put(event.getPlayer().getName(), System.currentTimeMillis());
+    	Player player = event.getPlayer();
+		
+    	Portal.joinCooldown.put(player.getName(), System.currentTimeMillis());
+	
+    	String uuid = player.getUniqueId().toString();
+    	
+    	if (plugin.PlayerDestiMap.containsKey(uuid)) {
+			plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+				Destination.warp(player, plugin.PlayerDestiMap.get(uuid), false, true);
+				plugin.PlayerDestiMap.remove(uuid);
+				
+			}, 1L);
+			
+    	}
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
@@ -31,21 +31,24 @@ public class PluginMessageReceiver implements PluginMessageListener {
 
         if (subchannel.equals(BungeeMessages.SERVER_DESTI)) {
             String targetDestination = in.readUTF();
-            UUID bungeeUUID = UUID.fromString(in.readUTF());
+            String bungeeUUID = in.readUTF();
+            
+            Player targetPlayer = this.plugin.getServer().getPlayer(UUID.fromString(bungeeUUID));
 
-            plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
-            	Player targetPlayer = this.plugin.getServer().getPlayer(bungeeUUID);
+            if (targetPlayer != null) {
+                Player finalTargetPlayer = targetPlayer;
+                Destination.warp(finalTargetPlayer, targetDestination, false, true);
+
+            }
+            else {
+                plugin.PlayerDestiMap.put(bungeeUUID, targetDestination);
                 
-            	if (targetPlayer != null) {
-                    Player finalTargetPlayer = targetPlayer;
-                    Destination.warp(finalTargetPlayer, targetDestination, false, true);
-                }
-                else {
-                    plugin.getLogger().warning("Could not find player to teleport to destination");
-                }
-                
-                
-            }, 20);
+                plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () ->
+                	plugin.PlayerDestiMap.remove(bungeeUUID),
+                	20L*10
+                );
+            }
+            
         }
     }
 

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
@@ -33,18 +33,19 @@ public class PluginMessageReceiver implements PluginMessageListener {
             String targetDestination = in.readUTF();
             UUID bungeeUUID = UUID.fromString(in.readUTF());
 
-            Player targetPlayer = this.plugin.getServer().getPlayer(bungeeUUID);
-
-            if (targetPlayer != null) {
-                Player finalTargetPlayer = targetPlayer;
-                plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin,
-                        () -> Destination.warp(finalTargetPlayer, targetDestination, false, true),
-                        20L
-                );
-            }
-            else {
-                plugin.getLogger().warning("Could not find player to teleport to destination");
-            }
+            plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+            	Player targetPlayer = this.plugin.getServer().getPlayer(bungeeUUID);
+                
+            	if (targetPlayer != null) {
+                    Player finalTargetPlayer = targetPlayer;
+                    Destination.warp(finalTargetPlayer, targetDestination, false, true);
+                }
+                else {
+                    plugin.getLogger().warning("Could not find player to teleport to destination");
+                }
+                
+                
+            }, 20);
         }
     }
 


### PR DESCRIPTION
Warp player when PluginMessage arrives if the player has already joined. Otherwise cache the data from the PluginMessage and handle the warp during PlayerJoinEvent.