### PR TITLE
Command permissions for luckperms

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,10 +9,12 @@ commands:
     description: The main command for the advanced portals
     aliases: [portals, aportals, portal, ap]
     usage: /<command>
+    permission: advancedportals.portal
   destination:
     description: Can be used to access portal destinations.
     aliases: [desti]
     usage: /<command>
+    permission: advancedportals.desti
 permissions:
   advancedportals.*:
     description: Gives access to all commands


### PR DESCRIPTION
Luckperms tries to hide commands you dont have access to. But this works only if the permissions for the commands were set in plugin.yml.

Before:
![Before](https://user-images.githubusercontent.com/16339036/106955526-67b1a880-6746-11eb-8e06-7f4e6d1723e5.png)


After:
![After](https://user-images.githubusercontent.com/16339036/106955764-bc552380-6746-11eb-8f12-646c9ed3a2f7.png)
