### PR TITLE
chore(ci): Update version-bumping task order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,8 +389,9 @@ task updateVersionNumbers {
     }
 }
 
+updateVersion.finalizedBy 'updateVersionNumbers'
+
 compileJava.dependsOn 'cleanbuildfolder'
-compileJava.dependsOn 'updateVersionNumbers'
 
 // Publish rules
 // Current behavior seems to be canary or release. Though pre-releases may break this pattern.


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR to [discord](https://discord.sekwah.com/) as canary version: <code>0.6.0--canary.263.03a8363</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
