### PR TITLE
fix: Access to portal warp command locked behind wrong perm

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,7 +9,7 @@ commands:
     description: The main command for the advanced portals
     aliases: [portals, aportals, portal, ap]
     usage: /<command>
-    permission: advancedportals.portal
+    permission: advancedportals.portalcommand
   destination:
     description: Can be used to access portal destinations.
     aliases: [desti]
@@ -50,6 +50,9 @@ permissions:
   advancedportals.portal:
     description: Allows use of portal commands
     default: op
+  advancedportals.portalcommand:
+    description: Access to the portal command. This is seperate to allow access to portal warps without the rest.
+    default: true
   advancedportals.build:
     description: Allows you to build in the portal regions
     default: op


### PR DESCRIPTION
# What Changed
The issue is with the current perm its both for the internal command code and spigot's system. So you get too much access.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR to [discord](https://discord.sekwah.com/) as canary version: <code>0.7.0--canary.275.895fcc6</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
