### PR TITLE
Fix teleportDelay not working

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PluginMessageReceiver.java
@@ -15,12 +15,12 @@ import java.util.UUID;
 public class PluginMessageReceiver implements PluginMessageListener {
 
     private final AdvancedPortalsPlugin plugin;
-    private final int teleportDelay;
+    private final double teleportDelay;
 
     public PluginMessageReceiver(AdvancedPortalsPlugin plugin) {
         this.plugin = plugin;
         ConfigAccessor config = new ConfigAccessor(plugin, "config.yml");
-        teleportDelay = config.getConfig().getInt(ConfigHelper.PROXY_TELEPORT_DELAY, 0);
+        teleportDelay = config.getConfig().getDouble(ConfigHelper.PROXY_TELEPORT_DELAY, 0);
     }
 
     @Override
@@ -37,14 +37,12 @@ public class PluginMessageReceiver implements PluginMessageListener {
             String targetDestination = in.readUTF();
             String bungeeUUID = in.readUTF();
 
-            Player targetPlayer = this.plugin.getServer().getPlayer(UUID.fromString(bungeeUUID));
-
             if(teleportDelay <= 0) {
-                teleportPlayerToDesti(targetPlayer, targetDestination, bungeeUUID);
+                teleportPlayerToDesti(player, targetDestination, bungeeUUID);
             } else {
                 plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () ->
-                                teleportPlayerToDesti(targetPlayer, targetDestination, bungeeUUID),
-                        20L * teleportDelay
+                                teleportPlayerToDesti(player, targetDestination, bungeeUUID),
+                        (long)(20.0 * teleportDelay)
                 );
             }
 


### PR DESCRIPTION
`this.plugin.getServer().getPlayer(UUID.fromString(bungeeUUID));` seemed to always return null for me when setting teleportDelay. Making it impossible to teleport with a delay as it had no user to teleport. Now using the player that invokes the event and it works without problem.

I've additionally made it possible to make teleportDelay less than a second to make more seamless transitions possible.