### PR TITLE
Add WorldEdit integration to AdvancedPortals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,8 +88,8 @@ dependencies {
     implementation "org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT"
     implementation "net.md-5:bungeecord-api:1.16-R0.4"
 
-    implementation "com.velocitypowered:velocity-api:1.1.9"
-    annotationProcessor "com.velocitypowered:velocity-api:1.1.9"
+    implementation "com.velocitypowered:velocity-api:3.1.0"
+    annotationProcessor "com.velocitypowered:velocity-api:3.1.0"
 
     implementation "io.netty:netty-all:4.1.71.Final"
     compileOnly 'com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     maven { url "https://nexus.velocitypowered.com/repository/maven-public/" }
     maven { url 'https://papermc.io/repo/repository/maven-public/' }
+    maven { url 'https://maven.enginehub.org/repo/' } // WorldEdit
 }
 
 // includeLibs just says to include the library in the final jar
@@ -94,6 +95,7 @@ dependencies {
     implementation "io.netty:netty-all:4.1.71.Final"
     compileOnly 'com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT'
 
+    implementation "com.sk89q.worldedit:worldedit-bukkit:7.2.6"
     //compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 

--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
@@ -9,6 +9,7 @@ import com.sekwah.advancedportals.bukkit.listeners.*;
 import com.sekwah.advancedportals.bukkit.metrics.Metrics;
 import com.sekwah.advancedportals.bukkit.portals.Portal;
 import com.sekwah.advancedportals.bungee.BungeeMessages;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -25,6 +26,8 @@ public class AdvancedPortalsPlugin extends JavaPlugin {
 
     protected boolean forceRegisterProxyChannels = false;
     protected boolean disableProxyWarning = false;
+
+    private boolean worldEditActive = false;
 
     protected static final Map<String, String> PLAYER_DESTI_MAP = new HashMap<>();
 
@@ -77,6 +80,10 @@ public class AdvancedPortalsPlugin extends JavaPlugin {
                 this.getServer().getOnlinePlayers()) {
             player.removeMetadata(Listeners.HAS_WARPED, this);
             player.removeMetadata(Listeners.LAVA_WARPED, this);
+        }
+
+        if (settings.enabledWorldEditIntegration() && Bukkit.getPluginManager().isPluginEnabled("WorldEdit")) {
+            worldEditActive = true;
         }
 
         // thanks to the new config accessor code the config.saveDefaultConfig(); will now
@@ -171,5 +178,9 @@ public class AdvancedPortalsPlugin extends JavaPlugin {
 
     public Settings getSettings() {
         return settings;
+    }
+
+    public boolean isWorldEditActive() {
+        return worldEditActive;
     }
 }

--- a/src/main/java/com/sekwah/advancedportals/bukkit/Settings.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/Settings.java
@@ -15,10 +15,13 @@ public class Settings {
 
     private String commandLevels = "n";
 
+    private boolean worldEditEnabled = false;
+
     public enum PortalConfigOption {
         COMMAND_LEVELS("CommandLevels"),
         WARP_PARTICLES("WarpParticles"),
-        WARP_SOUND("WarpSound");
+        WARP_SOUND("WarpSound"),
+        WORLDEDIT_INTEGRATION("WorldEditIntegration");
 
         private final String target;
 
@@ -37,6 +40,8 @@ public class Settings {
         currentWarpSound = config.getConfig().getInt(WARP_SOUND.value());
 
         commandLevels = config.getConfig().getString(COMMAND_LEVELS.value(), "opcb");
+
+        worldEditEnabled = config.getConfig().getBoolean(WORLDEDIT_INTEGRATION.value(), false);
 
         assert commandLevels != null;
         if(commandLevels.equals("opchek")) {
@@ -62,5 +67,9 @@ public class Settings {
 
     public int getCurrentWarpParticles() {
         return currentWarpParticles;
+    }
+
+    public boolean enabledWorldEditIntegration() {
+        return worldEditEnabled;
     }
 }

--- a/src/main/java/com/sekwah/advancedportals/bukkit/config/ConfigHelper.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/config/ConfigHelper.java
@@ -35,6 +35,7 @@ public class ConfigHelper {
         } else if(configVersion.equals("0.5.4")) {
             config.set(ConfigHelper.CONFIG_VERSION, "0.5.11");
             config.set(ConfigHelper.COMMAND_LOGS, true);
+            update();
         } else if(configVersion.equals("0.5.10") || configVersion.equals("0.5.11")) {
             config.set(ConfigHelper.CONFIG_VERSION, "0.5.13");
             config.set(ConfigHelper.FORCE_ENABLE_PROXY_SUPPORT, false);

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
@@ -329,49 +329,47 @@ public class Listeners implements Listener {
         }
 
         if (player.hasPermission("advancedportals.createportal")) {
-            if (!plugin.getSettings().enabledWorldEditIntegration()) {
-                if (event.getItem() != null && event.getItem().getType() == WandMaterial // was type id
-                        && (!UseOnlyServerAxe || (checkItemForName(event.getItem()) && event.getItem().getItemMeta()
-                        .getDisplayName().equals("\u00A7ePortal Region Selector")))) {
+            if (!plugin.getSettings().enabledWorldEditIntegration()
+                    && event.getItem() != null && event.getItem().getType() == WandMaterial // was type id
+                    && (!UseOnlyServerAxe || (checkItemForName(event.getItem()) && event.getItem().getItemMeta()
+                    .getDisplayName().equals("\u00A7ePortal Region Selector")))) {
 
-                    // This checks if the action was a left or right click and if it was directly
-                    // effecting a block.
-                    if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
-                        Location blockloc = event.getClickedBlock().getLocation();
-                        // stores the selection as metadata on the character so then it isn't saved
-                        // anywhere, if the player logs out it will
-                        // have to be selected again if the player joins, also it does not affect any
-                        // other players.
-                        player.setMetadata("Pos1X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
-                        player.setMetadata("Pos1Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
-                        player.setMetadata("Pos1Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
-                        player.setMetadata("Pos1World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
-                        player.sendMessage(
-                                "\u00A7eYou have selected pos1! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
-                                        + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
+                // This checks if the action was a left or right click and if it was directly
+                // effecting a block.
+                if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+                    Location blockloc = event.getClickedBlock().getLocation();
+                    // stores the selection as metadata on the character so then it isn't saved
+                    // anywhere, if the player logs out it will
+                    // have to be selected again if the player joins, also it does not affect any
+                    // other players.
+                    player.setMetadata("Pos1X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
+                    player.setMetadata("Pos1Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
+                    player.setMetadata("Pos1Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
+                    player.setMetadata("Pos1World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
+                    player.sendMessage(
+                            "\u00A7eYou have selected pos1! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
+                                    + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
 
-                        // Stops the event so the block is not damaged
-                        event.setCancelled(true);
+                    // Stops the event so the block is not damaged
+                    event.setCancelled(true);
 
-                        // Returns the event so no more code is executed(stops unnecessary code being
-                        // executed)
-                    } else if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-                        Location blockloc = event.getClickedBlock().getLocation();
-                        player.setMetadata("Pos2X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
-                        player.setMetadata("Pos2Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
-                        player.setMetadata("Pos2Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
-                        player.setMetadata("Pos2World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
-                        player.sendMessage(
-                                "\u00A7eYou have selected pos2! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
-                                        + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
+                    // Returns the event so no more code is executed(stops unnecessary code being
+                    // executed)
+                } else if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+                    Location blockloc = event.getClickedBlock().getLocation();
+                    player.setMetadata("Pos2X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
+                    player.setMetadata("Pos2Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
+                    player.setMetadata("Pos2Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
+                    player.setMetadata("Pos2World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
+                    player.sendMessage(
+                            "\u00A7eYou have selected pos2! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
+                                    + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
 
-                        // Stops the event so the block is not interacted with
-                        event.setCancelled(true);
+                    // Stops the event so the block is not interacted with
+                    event.setCancelled(true);
 
-                        // Returns the event so no more code is executed(stops unnecessary code being
-                        // executed)
-                    }
-
+                    // Returns the event so no more code is executed(stops unnecessary code being
+                    // executed)
                 }
             } else if (checkItemForName(event.getItem())
                     && event.getItem().getItemMeta().getDisplayName().equals("\u00A75Portal Block Placer")

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
@@ -329,49 +329,50 @@ public class Listeners implements Listener {
         }
 
         if (player.hasPermission("advancedportals.createportal")) {
+            if (!plugin.getSettings().enabledWorldEditIntegration()) {
+                if (event.getItem() != null && event.getItem().getType() == WandMaterial // was type id
+                        && (!UseOnlyServerAxe || (checkItemForName(event.getItem()) && event.getItem().getItemMeta()
+                        .getDisplayName().equals("\u00A7ePortal Region Selector")))) {
 
-            if (event.getItem() != null && event.getItem().getType() == WandMaterial // was type id
-                    && (!UseOnlyServerAxe || (checkItemForName(event.getItem()) && event.getItem().getItemMeta()
-                    .getDisplayName().equals("\u00A7ePortal Region Selector")))) {
+                    // This checks if the action was a left or right click and if it was directly
+                    // effecting a block.
+                    if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+                        Location blockloc = event.getClickedBlock().getLocation();
+                        // stores the selection as metadata on the character so then it isn't saved
+                        // anywhere, if the player logs out it will
+                        // have to be selected again if the player joins, also it does not affect any
+                        // other players.
+                        player.setMetadata("Pos1X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
+                        player.setMetadata("Pos1Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
+                        player.setMetadata("Pos1Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
+                        player.setMetadata("Pos1World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
+                        player.sendMessage(
+                                "\u00A7eYou have selected pos1! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
+                                        + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
 
-                // This checks if the action was a left or right click and if it was directly
-                // effecting a block.
-                if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
-                    Location blockloc = event.getClickedBlock().getLocation();
-                    // stores the selection as metadata on the character so then it isn't saved
-                    // anywhere, if the player logs out it will
-                    // have to be selected again if the player joins, also it does not affect any
-                    // other players.
-                    player.setMetadata("Pos1X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
-                    player.setMetadata("Pos1Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
-                    player.setMetadata("Pos1Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
-                    player.setMetadata("Pos1World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
-                    player.sendMessage(
-                            "\u00A7eYou have selected pos1! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
-                                    + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
+                        // Stops the event so the block is not damaged
+                        event.setCancelled(true);
 
-                    // Stops the event so the block is not damaged
-                    event.setCancelled(true);
+                        // Returns the event so no more code is executed(stops unnecessary code being
+                        // executed)
+                    } else if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+                        Location blockloc = event.getClickedBlock().getLocation();
+                        player.setMetadata("Pos2X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
+                        player.setMetadata("Pos2Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
+                        player.setMetadata("Pos2Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
+                        player.setMetadata("Pos2World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
+                        player.sendMessage(
+                                "\u00A7eYou have selected pos2! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
+                                        + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
 
-                    // Returns the event so no more code is executed(stops unnecessary code being
-                    // executed)
-                } else if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-                    Location blockloc = event.getClickedBlock().getLocation();
-                    player.setMetadata("Pos2X", new FixedMetadataValue(plugin, blockloc.getBlockX()));
-                    player.setMetadata("Pos2Y", new FixedMetadataValue(plugin, blockloc.getBlockY()));
-                    player.setMetadata("Pos2Z", new FixedMetadataValue(plugin, blockloc.getBlockZ()));
-                    player.setMetadata("Pos2World", new FixedMetadataValue(plugin, blockloc.getWorld().getName()));
-                    player.sendMessage(
-                            "\u00A7eYou have selected pos2! X:" + blockloc.getBlockX() + " Y:" + blockloc.getBlockY()
-                                    + " Z:" + blockloc.getBlockZ() + " World: " + blockloc.getWorld().getName());
+                        // Stops the event so the block is not interacted with
+                        event.setCancelled(true);
 
-                    // Stops the event so the block is not interacted with
-                    event.setCancelled(true);
+                        // Returns the event so no more code is executed(stops unnecessary code being
+                        // executed)
+                    }
 
-                    // Returns the event so no more code is executed(stops unnecessary code being
-                    // executed)
                 }
-
             } else if (checkItemForName(event.getItem())
                     && event.getItem().getItemMeta().getDisplayName().equals("\u00A75Portal Block Placer")
                     && event.getAction() == Action.LEFT_CLICK_BLOCK

--- a/src/main/java/com/sekwah/advancedportals/bukkit/util/WorldEditIntegration.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/util/WorldEditIntegration.java
@@ -1,0 +1,47 @@
+package com.sekwah.advancedportals.bukkit.util;
+
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.LocalSession;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.regions.RegionSelector;
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class WorldEditIntegration {
+    private static Region getCurrentSelection(Player player) {
+        LocalSession localSession = WorldEdit.getInstance().getSessionManager().get(BukkitAdapter.adapt(player));
+        try {
+            return localSession.getSelection(BukkitAdapter.adapt(player.getWorld()));
+        } catch (IncompleteRegionException e) {
+            return null;
+        }
+    }
+
+    public static boolean validateSelection(Player player) {
+        return getCurrentSelection(player) instanceof CuboidRegion;
+    }
+
+    public static Location getPos1(Player player) {
+        Region currentSelection = getCurrentSelection(player);
+        if (!(currentSelection instanceof CuboidRegion)) return null;
+        return BukkitAdapter.adapt(player.getWorld(), ((CuboidRegion) currentSelection).getPos1());
+    }
+
+    public static Location getPos2(Player player) {
+        Region currentSelection = getCurrentSelection(player);
+        if (currentSelection == null) return null;;
+        return BukkitAdapter.adapt(player.getWorld(), ((CuboidRegion) currentSelection).getPos2());
+    }
+
+    public static void explainRegion(Player player, Location pos1, Location pos2) {
+        LocalSession localSession = WorldEdit.getInstance().getSessionManager().get(BukkitAdapter.adapt(player));
+        RegionSelector selector = new CuboidRegionSelector(BukkitAdapter.adapt(player.getWorld()), BukkitAdapter.asBlockVector(pos1), BukkitAdapter.asBlockVector(pos2));
+        localSession.setRegionSelector(BukkitAdapter.adapt(player.getWorld()), selector);
+        selector.explainRegionAdjust(BukkitAdapter.adapt(player), localSession);
+
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -101,3 +101,7 @@ ProxyTeleportDelay: 0
 
 # Just in case you are not using the proxy and dont want the warning message
 DisableProxyWarning: false
+
+# Whether the integration with worldedit should be enabled.
+# This will force AdvancedPortals to use WorldEdit selections.
+WorldEditIntegration: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,10 @@ version: 0.8.0
 author: sekwah41
 description: An advanced portals plugin for bukkit.
 api-version: 1.13
+
+softdepend:
+  - WorldEdit
+
 commands:
   advancedportals:
     description: The main command for the advanced portals


### PR DESCRIPTION
As mentioned here, you're fine with a WorldEdit integration.
https://github.com/sekwah41/Advanced-Portals/issues/44

And I want to add it in this PR.

I really like AdvancedPortals but too many wands are terrible. I added a config option to enable WorldEdit integration.
With that option:
- AdvancedPortals uses the WorldEdit selections (has to be a cuboid selection, uses the same player world. This is a limitation but imo it's not that big problem. 
- Disable /portal wand and /portal selector when WorldEdit integration is active

When WorldEdit is installed:
- Add /portal we-selection <name> to select the portal as worldedit selection

WorldEdit is marked as soft-depend, you don't need to install worldedit for AdvancedPortals.