### PR TITLE
make "portal reload" command usable from the console and rcon

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsCommand.java
@@ -55,6 +55,15 @@ public class AdvancedPortalsCommand implements CommandExecutor, TabCompleter {
         ConfigAccessor config = new ConfigAccessor(plugin, "config.yml");
         ConfigAccessor portalConfig = new ConfigAccessor(plugin, "portals.yml");
         if (!(sender instanceof Player)) {
+            if(args.length == 1) {
+                if(args[0].equalsIgnoreCase("reload")) {
+                    Listeners.reloadValues(plugin);
+                    Portal.loadPortals();
+                    sender.sendMessage("portal reloaded.");
+
+                    return true;
+                }
+            }
             sender.sendMessage(PluginMessages.customPrefixFail + " You cannot use commands with the console.");
             return true;
         }


### PR DESCRIPTION
For my use case, I need to be able to reload the portal config from the console and/or rcon.  However that doesn't work:

```
[17:08:29 INFO]: [AdvancedPortals] You cannot use commands with the console.
```

This small change in the command handler addresses this specific issue.
I'm not sure why this restriction is in place, but this results in the behavior I need...

