### PR TITLE
feat: add custom messages to plugin

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/AdvancedPortalsPlugin.java
@@ -61,6 +61,10 @@ public class AdvancedPortalsPlugin extends JavaPlugin {
         ConfigAccessor destinationConfig = new ConfigAccessor(this, "destinations.yml");
         destinationConfig.saveDefaultConfig();
 
+
+        ConfigAccessor messagesConfig = new ConfigAccessor(this, "messages.yml");
+        messagesConfig.saveDefaultConfig();;
+
         this.settings = new Settings(this);
 
         // Loads the portal and destination editors

--- a/src/main/java/com/sekwah/advancedportals/bukkit/PluginMessages.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/PluginMessages.java
@@ -3,28 +3,35 @@ package com.sekwah.advancedportals.bukkit;
 import com.sekwah.advancedportals.bukkit.config.ConfigAccessor;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.checkerframework.checker.regex.qual.Regex;
 
 public class PluginMessages {
     private static String WARP_MESSAGE;
     private static String COOLDOWN_PROTECTION_MESSAGE;
     private static String PORTAL_COOLDOWN_MESSAGE;
     private static String NO_PERMISSION_PORTAL;
+    private static String NO_BUILD_PERMISSION;
     public boolean useCustomPrefix = false;
-    public static String customPrefix = "\u00A7a[\u00A7eAdvancedPortals\u00A7a]";
-    public static String customPrefixFail = "\u00A7c[\u00A77AdvancedPortals\u00A7c]";
+    public static String customPrefix = "§a[§eAdvancedPortals§a]";
+    public static String customPrefixFail = "§c[§7AdvancedPortals§c]";
 
+    // TODO: Create function for replacing all '&'
     public PluginMessages (AdvancedPortalsPlugin plugin) {
         ConfigAccessor config = new ConfigAccessor(plugin, "messages.yml");
+
         this.useCustomPrefix = config.getConfig().getBoolean("UseCustomPrefix");
+        String regexColorConverter = "&(?=[0-9a-fk-orx])";
+
         if (useCustomPrefix) {
-            PluginMessages.customPrefix = config.getConfig().getString("CustomPrefix").replaceAll("&(?=[0-9a-fk-or])", "\u00A7");
-            PluginMessages.customPrefixFail = config.getConfig().getString("CustomPrefixFail").replaceAll("&(?=[0-9a-fk-or])", "\u00A7");
+            PluginMessages.customPrefix = config.getConfig().getString("CustomPrefix", "§a[§eAdvancedPortals§a]").replaceAll(regexColorConverter, "§");
+            PluginMessages.customPrefixFail = config.getConfig().getString("CustomPrefixFail", "§c[§7AdvancedPortals§c]").replaceAll(regexColorConverter, "§");
         }
 
-        WARP_MESSAGE = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("WarpMessage", "&aYou have warped to &e<warp>&a"));
-        COOLDOWN_PROTECTION_MESSAGE = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("CooldownMessage", "&cThere is &e<time>&c join cooldown protection left."));
-        NO_PERMISSION_PORTAL = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("NoPermissionPortal", "&cYou do not have permission to use this portal!"));
-        PORTAL_COOLDOWN_MESSAGE = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("PortalCooldownMessage", "&cPlease wait &e<time> &cuntil attempting to enter this portal again"));
+        WARP_MESSAGE = config.getConfig().getString("WarpMessage", "§aYou have warped to §e<warp>§a").replaceAll(regexColorConverter, "§");
+        COOLDOWN_PROTECTION_MESSAGE = config.getConfig().getString("CooldownMessage", "§cThere is §e<time>§c join cooldown protection left.").replaceAll(regexColorConverter, "§");
+        NO_PERMISSION_PORTAL = config.getConfig().getString("NoPermissionPortal", "§cYou do not have permission to use this portal!").replaceAll(regexColorConverter, "§");
+        PORTAL_COOLDOWN_MESSAGE = config.getConfig().getString("PortalCooldownMessage", "§cPlease wait §e<time> §cuntil attempting to enter this portal again").replaceAll(regexColorConverter, "§");
+        NO_BUILD_PERMISSION = config.getConfig().getString("NoBuildPermission", "§cYou don't have permission to build here!").replaceAll(regexColorConverter, "§");
     }
 
     // This class is so then the common messages in commands or just messages over the commands are the same and can be
@@ -40,18 +47,17 @@ public class PluginMessages {
         return COOLDOWN_PROTECTION_MESSAGE.replace("<time>", time + secondsOrSecond);
     }
 
-    public static String getPortalCooldownMessage(int time) {
-        String secondsOrSecond = (time == 1) ? " second" : " seconds";
-        return COOLDOWN_PROTECTION_MESSAGE.replace("<time>", time + secondsOrSecond);
-    }
-
     public static String getNoPermissionPortal() {
         return NO_PERMISSION_PORTAL;
     }
 
+    public static String getNoBuildPermission() {
+        return NO_BUILD_PERMISSION;
+    }
+
     public static void UnknownCommand(CommandSender sender, String command) {
         sender.sendMessage(customPrefixFail + " You need to type something after /" + command + "\n");
-        sender.sendMessage("\u00A7cIf you do not know what you can put or would like some help with the commands please type \u00A7e" + '"' + "\u00A7e/" + command + " help" + '"' + "\u00A7c\n");
+        sender.sendMessage("§cIf you do not know what you can put or would like some help with the commands please type §e" + '"' + "§e/" + command + " help" + '"' + "§c\n");
     }
 
     public static void NoPermission(CommandSender sender, String command) {

--- a/src/main/java/com/sekwah/advancedportals/bukkit/PluginMessages.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/PluginMessages.java
@@ -6,12 +6,15 @@ import org.bukkit.command.CommandSender;
 
 public class PluginMessages {
     private static String WARP_MESSAGE;
+    private static String COOLDOWN_PROTECTION_MESSAGE;
+    private static String PORTAL_COOLDOWN_MESSAGE;
+    private static String NO_PERMISSION_PORTAL;
     public boolean useCustomPrefix = false;
     public static String customPrefix = "\u00A7a[\u00A7eAdvancedPortals\u00A7a]";
     public static String customPrefixFail = "\u00A7c[\u00A77AdvancedPortals\u00A7c]";
 
     public PluginMessages (AdvancedPortalsPlugin plugin) {
-        ConfigAccessor config = new ConfigAccessor(plugin, "config.yml");
+        ConfigAccessor config = new ConfigAccessor(plugin, "messages.yml");
         this.useCustomPrefix = config.getConfig().getBoolean("UseCustomPrefix");
         if (useCustomPrefix) {
             PluginMessages.customPrefix = config.getConfig().getString("CustomPrefix").replaceAll("&(?=[0-9a-fk-or])", "\u00A7");
@@ -19,6 +22,9 @@ public class PluginMessages {
         }
 
         WARP_MESSAGE = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("WarpMessage", "&aYou have warped to &e<warp>&a"));
+        COOLDOWN_PROTECTION_MESSAGE = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("CooldownMessage", "&cThere is &e<time>&c join cooldown protection left."));
+        NO_PERMISSION_PORTAL = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("NoPermissionPortal", "&cYou do not have permission to use this portal!"));
+        PORTAL_COOLDOWN_MESSAGE = ChatColor.translateAlternateColorCodes('&', config.getConfig().getString("PortalCooldownMessage", "&cPlease wait &e<time> &cuntil attempting to enter this portal again"));
     }
 
     // This class is so then the common messages in commands or just messages over the commands are the same and can be
@@ -27,6 +33,20 @@ public class PluginMessages {
     public static String getWarpMessage(String warp) {
         String cleanedWarp = warp.replace("_", " ");
         return WARP_MESSAGE.replace("<warp>", cleanedWarp);
+    }
+
+    public static String getCooldownProtectionMessage(int time) {
+        String secondsOrSecond = (time == 1) ? " second" : " seconds";
+        return COOLDOWN_PROTECTION_MESSAGE.replace("<time>", time + secondsOrSecond);
+    }
+
+    public static String getPortalCooldownMessage(int time) {
+        String secondsOrSecond = (time == 1) ? " second" : " seconds";
+        return COOLDOWN_PROTECTION_MESSAGE.replace("<time>", time + secondsOrSecond);
+    }
+
+    public static String getNoPermissionPortal() {
+        return NO_PERMISSION_PORTAL;
     }
 
     public static void UnknownCommand(CommandSender sender, String command) {

--- a/src/main/java/com/sekwah/advancedportals/bukkit/PluginMessages.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/PluginMessages.java
@@ -28,7 +28,7 @@ public class PluginMessages {
         }
 
         WARP_MESSAGE = config.getConfig().getString("WarpMessage", "§aYou have warped to §e<warp>§a").replaceAll(regexColorConverter, "§");
-        COOLDOWN_PROTECTION_MESSAGE = config.getConfig().getString("CooldownMessage", "§cThere is §e<time>§c join cooldown protection left.").replaceAll(regexColorConverter, "§");
+        COOLDOWN_PROTECTION_MESSAGE = config.getConfig().getString("CooldownProtectionMessage", "§cThere is §e<time>§c join cooldown protection left.").replaceAll(regexColorConverter, "§");
         NO_PERMISSION_PORTAL = config.getConfig().getString("NoPermissionPortal", "§cYou do not have permission to use this portal!").replaceAll(regexColorConverter, "§");
         PORTAL_COOLDOWN_MESSAGE = config.getConfig().getString("PortalCooldownMessage", "§cPlease wait §e<time> §cuntil attempting to enter this portal again").replaceAll(regexColorConverter, "§");
         NO_BUILD_PERMISSION = config.getConfig().getString("NoBuildPermission", "§cYou don't have permission to build here!").replaceAll(regexColorConverter, "§");

--- a/src/main/java/com/sekwah/advancedportals/bukkit/destinations/Destination.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/destinations/Destination.java
@@ -29,8 +29,10 @@ public class Destination {
         Destination.plugin = plugin;
 
         ConfigAccessor config = new ConfigAccessor(plugin, "config.yml");
+        ConfigAccessor messagesConfig = new ConfigAccessor(plugin, "config.yml");
+
         TELEPORT_RIDING = config.getConfig().getBoolean("WarpRiddenEntity");
-        PORTAL_MESSAGE_DISPLAY = config.getConfig().getInt("WarpMessageDisplay");
+        PORTAL_MESSAGE_DISPLAY = messagesConfig.getConfig().getInt("WarpMessageDisplay");
     }
 
     // TODO add permissions for destinations.

--- a/src/main/java/com/sekwah/advancedportals/bukkit/destinations/Destination.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/destinations/Destination.java
@@ -29,7 +29,7 @@ public class Destination {
         Destination.plugin = plugin;
 
         ConfigAccessor config = new ConfigAccessor(plugin, "config.yml");
-        ConfigAccessor messagesConfig = new ConfigAccessor(plugin, "config.yml");
+        ConfigAccessor messagesConfig = new ConfigAccessor(plugin, "messages.yml");
 
         TELEPORT_RIDING = config.getConfig().getBoolean("WarpRiddenEntity");
         PORTAL_MESSAGE_DISPLAY = messagesConfig.getConfig().getInt("WarpMessageDisplay");
@@ -163,6 +163,8 @@ public class Destination {
                     WarpEffects.activateEffect(player);
                     WarpEffects.activateSound(player);
                 }
+
+                System.out.println(PORTAL_MESSAGE_DISPLAY);
 
                 if (PORTAL_MESSAGE_DISPLAY == 1) {
                     player.sendMessage("");

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
@@ -22,7 +22,6 @@ import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PortalProtect.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/PortalProtect.java
@@ -20,18 +20,16 @@ public class PortalProtect implements Listener {
 
     @SuppressWarnings("unused")
     private final AdvancedPortalsPlugin plugin;
-
     // The needed config values will be stored so they are easier to access later
     // an example is in the interact event in this if statement if((!UseOnlyServerAxe || event.getItem().getItemMeta().getDisplayName().equals("�eP...
-    private boolean PortalProtect = true;
-
-    private int PortalProtectionArea = 5;
+    private final boolean PortalProtect;
+    private final int PortalProtectionArea;
 
     public PortalProtect(AdvancedPortalsPlugin plugin) {
         this.plugin = plugin;
 
         ConfigAccessor config = new ConfigAccessor(plugin, "config.yml");
-        this.PortalProtect = config.getConfig().getBoolean("PortalProtection");
+        this.PortalProtect = config.getConfig().getBoolean("PortalProtection", true);
 
         this.PortalProtectionArea = config.getConfig().getInt("PortalProtectionArea", 5);
 
@@ -48,7 +46,7 @@ public class PortalProtect implements Listener {
         if (!player.hasPermission("advancedportals.build")
                 && Portal.inPortalRegion(event.getBlock().getLocation(), PortalProtectionArea)) {
             event.setCancelled(true);
-            player.sendMessage(PluginMessages.customPrefixFail + " You don't have permission to build here!");
+            player.sendMessage(String.join(" ",PluginMessages.customPrefixFail, PluginMessages.getNoBuildPermission()));
         }
     }
 
@@ -60,7 +58,7 @@ public class PortalProtect implements Listener {
         if (PortalProtect && !player.hasPermission("advancedportals.build")
                 && Portal.inPortalRegion(event.getBlock().getLocation(), PortalProtectionArea)) {
             event.setCancelled(true);
-            player.sendMessage(PluginMessages.customPrefixFail + " You don't have permission to build here!");
+            player.sendMessage(String.join(" ",PluginMessages.customPrefixFail, PluginMessages.getNoBuildPermission()));
         }
     }
 
@@ -77,6 +75,4 @@ public class PortalProtect implements Listener {
             }
         }
     }
-
-
 }

--- a/src/main/java/com/sekwah/advancedportals/bukkit/portals/Portal.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/portals/Portal.java
@@ -493,7 +493,7 @@ public class Portal {
                 }
                 if (diff < portalCooldown) {
                     int time = (portalCooldown - diff);
-                    player.sendMessage(PluginMessages.getPortalCooldownMessage(time));
+                    player.sendMessage(PluginMessages.getCooldownProtectionMessage(time));
                     failSound(player, portal);
                     if(doKnockback)
                         throwPlayerBack(player);
@@ -740,7 +740,7 @@ public class Portal {
     }
 
     public static void throwPlayerBack(Player player) {
-        // Not ensured to remove them out of the portal but it makes it feel nicer for
+        // Not ensured to remove them out of the portal, but it makes it feel nicer for
         // the player.
         if (throwback > 0) {
             Vector velocity = player.getLocation().getDirection();

--- a/src/main/java/com/sekwah/advancedportals/bukkit/portals/Portal.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/portals/Portal.java
@@ -459,7 +459,7 @@ public class Portal {
         if (!(permission == null || ((!invertPermission && player.hasPermission(permission)) || (invertPermission && !player.hasPermission(permission))) || player.isOp())) {
             if(!noMessage) {
                 player.sendMessage(
-                        PluginMessages.customPrefixFail + "\u00A7c You do not have permission to use this portal!");
+                        String.join(" ", PluginMessages.customPrefixFail, PluginMessages.getNoPermissionPortal()));
                 failSound(player, portal);
                 if(doKnockback)
                     throwPlayerBack(player);
@@ -472,7 +472,7 @@ public class Portal {
             int diff = (int) ((System.currentTimeMillis() - joinCD) / 1000);
             if (diff < joinCooldownDelay) {
                 int time = (joinCooldownDelay - diff);
-                player.sendMessage(ChatColor.RED + "There is " + ChatColor.YELLOW + time + ChatColor.RED + (time == 1 ? " second" : " seconds") + " join cooldown protection left.");
+                player.sendMessage(PluginMessages.getCooldownProtectionMessage(time));
                 failSound(player, portal);
                 if(doKnockback)
                     throwPlayerBack(player);
@@ -493,8 +493,7 @@ public class Portal {
                 }
                 if (diff < portalCooldown) {
                     int time = (portalCooldown - diff);
-                    player.sendMessage(ChatColor.RED + "Please wait " + ChatColor.YELLOW + time + ChatColor.RED
-                            + (time == 1 ? " second" : " seconds") + " until attempting to enter this portal again.");
+                    player.sendMessage(PluginMessages.getPortalCooldownMessage(time));
                     failSound(player, portal);
                     if(doKnockback)
                         throwPlayerBack(player);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,14 +5,14 @@
 # Will update whenever there is a config update from an older version so may not be the latest plugin version
 ConfigVersion: 0.5.13
 
-# Set to true if you want the normal axes to work normally but the ones gived with /portals selector or wand will still work though
-# It can be usefull if people with permission want to use an iron axe on a survival server
+# Set to true if you want the normal axes to work normally but the ones given with /portals selector or wand will still work though
+# It can be useful if people with permission want to use an iron axe on a survival server
 UseOnlyServerMadeAxe: false
 
-# Preferably an item and not a block but it shouldnt matter
+# Preferably an item and not a block but it shouldn't matter
 AxeItemId: IRON_AXE
 
-# Will be implemented so you can give yourself the portal block and build manually with it so its easier to make portals with the portal block.
+# Will be implemented, so you can give yourself the portal block and build manually with it, so it's easier to make portals with the portal block.
 CanBuildPortalBlock: true
 
 # Defines if portals protect themselves
@@ -24,11 +24,11 @@ PortalProtectionArea: 5
 # What the default trigger block is for portals if nothing is defined.
 DefaultPortalTriggerBlock: PORTAL
 
-# This stops all water flowing inside a portal area(can be disabled if something like world edit is handelling the water flow or you dont want it active)
+# This stops all water flowing inside a portal area(can be disabled if something like world edit is handling the water flow or you don't want it active)
 #    you want to
 StopWaterFlow: true
 
-# This must be a placeable block or it will not work and may even crash
+# This must be a placeable block, or it will not work and may even crash
 ShowSelectionBlockID: RED_STAINED_GLASS
 
 # WarpEffect
@@ -46,13 +46,8 @@ WarpSound: 1
 # In case you want to show the bungee attempting warp message
 ShowBungeeWarpMessage: false
 
-# This changes how long the show seletion lasts in seconds
-
+# This changes how long the show selection lasts in seconds
 ShowSelectionShowDuration: 10
-
-# Where to display the message 0 = disabled(replaces PortalWarpMessages), 1 = in chat and 2 = action bar(1.8 and above only, anything lower will print the message that would
-#  generally on the action bar in the chat without a prefix or extra chat formatting)
-WarpMessageDisplay: 2
 
 # Use plugin name in the warp messages
 UseWarpPrefix: true
@@ -65,12 +60,12 @@ ThrowbackAmount: 0.7 # How fast to throw them back, 0 or lower to disable throwb
 # Only disables the gateway block places with "/portal gatewayblock" for now
 # If you want to replace already made portals just use "/portal disablebeacon" and it will run through all the blocks in the area
 # Reloading the world or chunks that portals are in will also trigger the beacons to be disabled (this is for efficiency reasons)
-# However these wont trigger in the spawn chunks as they are loaded before any pluigns are.
+# However these won't trigger in the spawn chunks as they are loaded before any plugins are.
 DisableGatewayBeam: true
 
 # Enable or disable special command portals
 #
-# n Disabled none, best just put this to really make sure the fact none are here is specified. It disables any others too
+# n Disabled none, the best just put this to really make sure the fact none are here is specified. It disables any others too
 # o enable op command portals
 # p enable permission command portals
 # c enable console command portals
@@ -81,16 +76,16 @@ CommandLevels: opcb
 # Should the commands being triggered log in the console? (If you have an active server it may cause a bit of spam)
 CommandLogs: true
 
-# If you want to use bungee or velocity and it is not automatically detected (make sure you have advanced portals on the proxy, especially with velocity)
+# If you want to use bungee or velocity, and it is not automatically detected (make sure you have advanced portals on the proxy, especially with velocity)
 ForceEnableProxySupport: false
 
 # How many seconds after the proxy event fires should the player be teleported (should help with on spawn plugins and such)
 # 0 is disabled and anything higher causes a delay.
 ProxyTeleportDelay: 0
 
-# Just in case you are not using the proxy and dont want the warning message
+# Just in case you are not using the proxy and don't want the warning message
 DisableProxyWarning: false
 
-# Whether the integration with worldedit should be enabled.
+# Whether the integration with WorldEdit should be enabled.
 # This will force AdvancedPortals to use WorldEdit selections.
 WorldEditIntegration: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -57,17 +57,6 @@ WarpMessageDisplay: 2
 # Use plugin name in the warp messages
 UseWarpPrefix: true
 
-# If this is true a custom prefix can be used, (not fully coded yet!!)
-
-UseCustomPrefix: false
-
-CustomPrefix: '&a[&eAdvancedPortals&a]'
-
-CustomPrefixFail: '&c[&7AdvancedPortals&c]'
-
-# Message sent to player in chat/action bar on warp
-WarpMessage: '&aYou have warped to &e<warp>&a.'
-
 BlockSpectatorMode: false
 
 PortalCooldown: 5 # How long after trying to enter a portal until the player can try to enter another. 0 or lower to deactivate.

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,6 +11,10 @@ CustomPrefixFail: '&c[&7AdvancedPortals&c]'
 # Message sent to player in chat/action bar on warp
 WarpMessage: '&aYou have warped to &e<warp>&a.'
 
+# Where to display the message 0 = disabled(replaces PortalWarpMessages), 1 = in chat and 2 = action bar(1.8 and above only, anything lower will print the message that would
+#  generally on the action bar in the chat without a prefix or extra chat formatting)
+WarpMessageDisplay: 2
+
 # Message sent to player that has just joined the server trying to use a portal
 CooldownProtectionMessage: '&cThere is &e<time>&c join cooldown protection left.'
 
@@ -19,3 +23,7 @@ NoPermissionPortal: '&cYou do not have permission to use this portal!'
 
 # Message sent to player that has a portal cooldown
 PortalCooldownMessage: '&cPlease wait &e<time> &cuntil attempting to enter this portal again!'
+
+# Message sent to player when they attempt to break a block close to a portal
+NoBuildPermission: '&cYou don''t have permission to build here!'
+

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,0 +1,21 @@
+# Advanced Portals Messages
+
+# If this is true a custom prefix can be used, (not fully coded yet!!)
+
+UseCustomPrefix: false
+
+CustomPrefix: '&a[&eAdvancedPortals&a]'
+
+CustomPrefixFail: '&c[&7AdvancedPortals&c]'
+
+# Message sent to player in chat/action bar on warp
+WarpMessage: '&aYou have warped to &e<warp>&a.'
+
+# Message sent to player that has just joined the server trying to use a portal
+CooldownProtectionMessage: '&cThere is &e<time>&c join cooldown protection left.'
+
+# Message sent to player that doesn't have permission to use a portal
+NoPermissionPortal: '&cYou do not have permission to use this portal!'
+
+# Message sent to player that has a portal cooldown
+PortalCooldownMessage: '&cPlease wait &e<time> &cuntil attempting to enter this portal again!'


### PR DESCRIPTION
feat: add custom messages to several options:
1. Join Cooldown Protection
2. No Portal Permission
3. No Portal Cooldown

This is all moved to a new configuration file called messages.yml so that config.yml doesn't become convoluted (Including the move of prefix and warp message)

Fixes
#144
#224