### PR TITLE
FIX: Remove HAS_WARPED Metadata when logging into a new server

### DIFF
--- a/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
+++ b/src/main/java/com/sekwah/advancedportals/bukkit/listeners/Listeners.java
@@ -95,6 +95,8 @@ public class Listeners implements Listener {
     public void onJoinEvent(PlayerJoinEvent event) {
         Player player = event.getPlayer();
 
+        if(player.hasMetadata(HAS_WARPED)) player.removeMetadata(HAS_WARPED, plugin);
+
         Portal.joinCooldown.put(player.getName(), System.currentTimeMillis());
 
         Location loc = player.getLocation();


### PR DESCRIPTION
Checks if player has `HAS_WARPED` metadata when joining a server (shouldn't have it when logging/joining a server anyway) and removes it if they do. 

Alternatively it could be put in the `PlayerQuitEvent` but I don't think it should be fine for the `PlayerJoinEvent`.

Was tested in a live environment by @RillSoji

Fixes #329 

