### PR TITLE
fix: autocomplete strings come up with error.

### DIFF
--- a/core/src/main/java/com/sekwah/advancedportals/core/commands/CommandWithSubCommands.java
+++ b/core/src/main/java/com/sekwah/advancedportals/core/commands/CommandWithSubCommands.java
@@ -8,6 +8,7 @@ import com.sekwah.advancedportals.core.util.Lang;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommandWithSubCommands implements CommandTemplate {
 
@@ -171,7 +172,8 @@ public class CommandWithSubCommands implements CommandTemplate {
         if(tabList == null) {
             return null;
         }
-        tabList.removeIf(arg -> !arg.startsWith(lastArg));
-        return tabList;
+        return tabList.stream()
+                .filter(arg -> arg.startsWith(lastArg))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
	
So the list that is being filtered is immutable, hence doesn't work with in conjunction with removeIf.

There are two solutions, either
- stream it (which I've done in this PR since I believe it to be more efficient)
OR
- create a new ArrayList each time for filtering since that is mutable

```[13:00:27 ERROR]: Exception when FlippinDuckMan attempted to tab complete advancedportals create name:test3 command:"d
org.bukkit.command.CommandException: Unhandled exception during tab completion for command '/advancedportals create name:test3 command:"d' in plugin AdvancedPortals v1.0.0
	at org.bukkit.command.PluginCommand.tabComplete(PluginCommand.java:150) ~[PaperCrane-API-1.20.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.command.Command.tabComplete(Command.java:93) ~[PaperCrane-API-1.20.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.command.SimpleCommandMap.tabComplete(SimpleCommandMap.java:240) ~[PaperCrane-API-1.20.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R1.CraftServer.tabCompleteCommand(CraftServer.java:2420) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at org.bukkit.craftbukkit.v1_20_R1.CraftServer.tabComplete(CraftServer.java:2392) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at org.bukkit.craftbukkit.v1_20_R1.command.BukkitCommandWrapper.getSuggestions(BukkitCommandWrapper.java:74) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at com.mojang.brigadier.tree.ArgumentCommandNode.listSuggestions(ArgumentCommandNode.java:71) ~[brigadier-1.1.8.jar:git-Paper-"c09094b"]
	at com.mojang.brigadier.CommandDispatcher.getCompletionSuggestions(CommandDispatcher.java:602) ~[papercrane-1.20.1.jar:?]
	at com.mojang.brigadier.CommandDispatcher.getCompletionSuggestions(CommandDispatcher.java:582) ~[papercrane-1.20.1.jar:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleCustomCommandSuggestions$6(ServerGamePacketListenerImpl.java:922) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1337) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:197) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1314) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1307) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1285) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1173) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:317) ~[papercrane-1.20.1.jar:git-Paper-"c09094b"]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]```
