### PR TITLE
fix: lower java requirement to 8 for spigot builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,13 +36,13 @@ jobs:
           release-task: modrinth
           # Java 16 for spigot
         - project: spigot
-          java-version: 16
+          java-version: 8
           release-task: curseforge
         - project: spigot
-          java-version: 16
+          java-version: 8
           release-task: discordupload
         - project: spigot
-          java-version: 16
+          java-version: 8
           release-task: modrinth
     needs: release-please
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
         - project: spigot
-          java-version: 16
+          java-version: 8
         - project: legacyspigot
           java-version: 8
     steps:


### PR DESCRIPTION
As the main module needs java 8, might as well allow better support for back in 1.12 and such for lower java versions